### PR TITLE
Attributed text support      

### DIFF
--- a/AnimatedTextInput/Classes/AnimatedTextField.swift
+++ b/AnimatedTextInput/Classes/AnimatedTextField.swift
@@ -15,6 +15,8 @@ final internal class AnimatedTextField: UITextField {
     var rightViewPadding: CGFloat
     weak var textInputDelegate: TextInputDelegate?
 
+    var textAttributes: [String: Any]?
+
     fileprivate var disclosureButtonAction: ((Void) -> Void)?
 
     override init(frame: CGRect) {
@@ -61,6 +63,9 @@ final internal class AnimatedTextField: UITextField {
     }
 
     @objc fileprivate func textFieldDidChange() {
+        if let text = text {
+            attributedText = NSAttributedString(string: text, attributes: textAttributes)
+        }
         textInputDelegate?.textInputDidChange(textInput: self)
     }
 }
@@ -78,11 +83,6 @@ extension AnimatedTextField: TextInput {
     var currentText: String? {
         get { return text }
         set { self.text = newValue }
-    }
-
-    var textAttributes: [String: Any] {
-        get { return typingAttributes ?? [:] }
-        set { self.typingAttributes = textAttributes }
     }
 
     var currentSelectedTextRange: UITextRange? {

--- a/AnimatedTextInput/Classes/AnimatedTextInput.swift
+++ b/AnimatedTextInput/Classes/AnimatedTextInput.swift
@@ -53,6 +53,11 @@ open class AnimatedTextInput: UIControl {
             textInput.currentText = newValue
         }
     }
+    
+    open var textAttributes: [String: Any]? {
+        get { return textInput.textAttributes }
+        set { textInput.textAttributes = newValue }
+    }
 
     open var selectedTextRange: UITextRange? {
         get { return textInput.currentSelectedTextRange }
@@ -270,7 +275,7 @@ open class AnimatedTextInput: UIControl {
         return textInput.view.isFirstResponder
     }
 
-    override open func resignFirstResponder() -> Bool {
+    @discardableResult override open func resignFirstResponder() -> Bool {
         guard !isResigningResponder else { return true }
         isActive = false
         isResigningResponder = true
@@ -428,10 +433,10 @@ extension AnimatedTextInput: TextInputDelegate {
 
 public protocol TextInput {
     var view: UIView { get }
-
     var currentText: String? { get set }
     var font: UIFont? { get set }
     var textColor: UIColor? { get set }
+    var textAttributes: [String: Any]? { get set }
     weak var textInputDelegate: TextInputDelegate? { get set }
     var currentSelectedTextRange: UITextRange? { get set }
     var currentBeginningOfDocument: UITextPosition? { get }

--- a/AnimatedTextInput/Classes/AnimatedTextInput.swift
+++ b/AnimatedTextInput/Classes/AnimatedTextInput.swift
@@ -53,11 +53,6 @@ open class AnimatedTextInput: UIControl {
             textInput.currentText = newValue
         }
     }
-    
-    open var textAttributes: [String: Any]? {
-        get { return textInput.textAttributes }
-        set { textInput.textAttributes = newValue }
-    }
 
     open var selectedTextRange: UITextRange? {
         get { return textInput.currentSelectedTextRange }
@@ -66,6 +61,72 @@ open class AnimatedTextInput: UIControl {
 
     open var beginningOfDocument: UITextPosition? {
         get { return textInput.currentBeginningOfDocument }
+    }
+
+    open var lineSpacing: CGFloat? {
+        get {
+            guard let paragraph = textInput.textAttributes?[NSParagraphStyleAttributeName] as? NSParagraphStyle else { return nil }
+            return paragraph.lineSpacing
+        }
+        set {
+            guard let spacing = newValue else { return }
+            let paragraphStyle = textInput.textAttributes?[NSParagraphStyleAttributeName] as? NSMutableParagraphStyle ?? NSMutableParagraphStyle()
+            paragraphStyle.lineSpacing = spacing
+            textInput.textAttributes = [NSParagraphStyleAttributeName : paragraphStyle]
+        }
+    }
+
+    open var textAlignment: NSTextAlignment? {
+        get {
+            guard let paragraph = textInput.textAttributes?[NSParagraphStyleAttributeName] as? NSParagraphStyle else { return nil }
+            return paragraph.alignment
+        }
+        set {
+            guard let alignment = newValue else { return }
+            let paragraphStyle = textInput.textAttributes?[NSParagraphStyleAttributeName] as? NSMutableParagraphStyle ?? NSMutableParagraphStyle()
+            paragraphStyle.alignment = alignment
+            textInput.textAttributes = [NSParagraphStyleAttributeName : paragraphStyle]
+        }
+    }
+
+    open var tailIndent: CGFloat? {
+        get {
+            guard let paragraph = textInput.textAttributes?[NSParagraphStyleAttributeName] as? NSParagraphStyle else { return nil }
+            return paragraph.tailIndent
+        }
+        set {
+            guard let indent = newValue else { return }
+            let paragraphStyle = textInput.textAttributes?[NSParagraphStyleAttributeName] as? NSMutableParagraphStyle ?? NSMutableParagraphStyle()
+            paragraphStyle.tailIndent = indent
+            textInput.textAttributes = [NSParagraphStyleAttributeName : paragraphStyle]
+        }
+    }
+
+    open var headIndent: CGFloat? {
+        get {
+            guard let paragraph = textInput.textAttributes?[NSParagraphStyleAttributeName] as? NSParagraphStyle else { return nil }
+            return paragraph.headIndent
+        }
+        set {
+            guard let indent = newValue else { return }
+            let paragraphStyle = textInput.textAttributes?[NSParagraphStyleAttributeName] as? NSMutableParagraphStyle ?? NSMutableParagraphStyle()
+            paragraphStyle.headIndent = indent
+            textInput.textAttributes = [NSParagraphStyleAttributeName : paragraphStyle]
+        }
+    }
+
+    open var textAttributes: [String: Any]? {
+        didSet {
+            guard var textInputAttributes = textInput.textAttributes else {
+                textInput.textAttributes = textAttributes
+                return
+            }
+            guard textAttributes != nil else {
+                textInput.textAttributes = nil
+                return
+            }
+            textInputAttributes.merge(dict: textAttributes!)
+        }
     }
 
     fileprivate let lineView = AnimatedLine()
@@ -469,3 +530,10 @@ public protocol TextInputError {
     func configureErrorState(with message: String?)
     func removeErrorHintMessage()
 }
+
+fileprivate extension Dictionary {
+    mutating func merge(dict: [Key: Value]) {
+        for (key, value) in dict { self[key] = value }
+    }
+}
+

--- a/AnimatedTextInput/Classes/AnimatedTextInput.swift
+++ b/AnimatedTextInput/Classes/AnimatedTextInput.swift
@@ -348,9 +348,13 @@ open class AnimatedTextInput: UIControl {
         }
     }
 
-    open func showCharacterCounterLabel(with maximum: Int) {
+    open func showCharacterCounterLabel(with maximum: Int? = nil) {
         let characters = (text != nil) ? text!.characters.count : 0
-        counterLabel.text = "\(characters)/\(maximum)"
+        if let maximumValue = maximum {
+            counterLabel.text = "\(characters)/\(maximumValue)"
+        } else {
+            counterLabel.text = "\(characters)"
+        }
         counterLabel.textColor = isActive ? style.activeColor : style.inactiveColor
         counterLabel.font = style.counterLabelFont
         counterLabel.translatesAutoresizingMaskIntoConstraints = false

--- a/AnimatedTextInput/Classes/AnimatedTextInput.swift
+++ b/AnimatedTextInput/Classes/AnimatedTextInput.swift
@@ -63,16 +63,26 @@ open class AnimatedTextInput: UIControl {
         get { return textInput.currentBeginningOfDocument }
     }
 
+    open var font: UIFont? {
+        get { return textInput.font }
+        set { textAttributes = [NSFontAttributeName: newValue] }
+    }
+
+    open var textColor: UIColor? {
+        get { return textInput.textColor }
+        set { textAttributes = [NSForegroundColorAttributeName: newValue] }
+    }
+
     open var lineSpacing: CGFloat? {
         get {
-            guard let paragraph = textInput.textAttributes?[NSParagraphStyleAttributeName] as? NSParagraphStyle else { return nil }
+            guard let paragraph = textAttributes?[NSParagraphStyleAttributeName] as? NSParagraphStyle else { return nil }
             return paragraph.lineSpacing
         }
         set {
             guard let spacing = newValue else { return }
-            let paragraphStyle = textInput.textAttributes?[NSParagraphStyleAttributeName] as? NSMutableParagraphStyle ?? NSMutableParagraphStyle()
+            let paragraphStyle = textAttributes?[NSParagraphStyleAttributeName] as? NSMutableParagraphStyle ?? NSMutableParagraphStyle()
             paragraphStyle.lineSpacing = spacing
-            textInput.textAttributes = [NSParagraphStyleAttributeName : paragraphStyle]
+            textAttributes = [NSParagraphStyleAttributeName: paragraphStyle]
         }
     }
 
@@ -83,35 +93,35 @@ open class AnimatedTextInput: UIControl {
         }
         set {
             guard let alignment = newValue else { return }
-            let paragraphStyle = textInput.textAttributes?[NSParagraphStyleAttributeName] as? NSMutableParagraphStyle ?? NSMutableParagraphStyle()
+            let paragraphStyle = textAttributes?[NSParagraphStyleAttributeName] as? NSMutableParagraphStyle ?? NSMutableParagraphStyle()
             paragraphStyle.alignment = alignment
-            textInput.textAttributes = [NSParagraphStyleAttributeName : paragraphStyle]
+            textAttributes = [NSParagraphStyleAttributeName: paragraphStyle]
         }
     }
 
     open var tailIndent: CGFloat? {
         get {
-            guard let paragraph = textInput.textAttributes?[NSParagraphStyleAttributeName] as? NSParagraphStyle else { return nil }
+            guard let paragraph = textAttributes?[NSParagraphStyleAttributeName] as? NSParagraphStyle else { return nil }
             return paragraph.tailIndent
         }
         set {
             guard let indent = newValue else { return }
-            let paragraphStyle = textInput.textAttributes?[NSParagraphStyleAttributeName] as? NSMutableParagraphStyle ?? NSMutableParagraphStyle()
+            let paragraphStyle = textAttributes?[NSParagraphStyleAttributeName] as? NSMutableParagraphStyle ?? NSMutableParagraphStyle()
             paragraphStyle.tailIndent = indent
-            textInput.textAttributes = [NSParagraphStyleAttributeName : paragraphStyle]
+            textAttributes = [NSParagraphStyleAttributeName: paragraphStyle]
         }
     }
 
     open var headIndent: CGFloat? {
         get {
-            guard let paragraph = textInput.textAttributes?[NSParagraphStyleAttributeName] as? NSParagraphStyle else { return nil }
+            guard let paragraph = textAttributes?[NSParagraphStyleAttributeName] as? NSParagraphStyle else { return nil }
             return paragraph.headIndent
         }
         set {
             guard let indent = newValue else { return }
-            let paragraphStyle = textInput.textAttributes?[NSParagraphStyleAttributeName] as? NSMutableParagraphStyle ?? NSMutableParagraphStyle()
+            let paragraphStyle = textAttributes?[NSParagraphStyleAttributeName] as? NSMutableParagraphStyle ?? NSMutableParagraphStyle()
             paragraphStyle.headIndent = indent
-            textInput.textAttributes = [NSParagraphStyleAttributeName : paragraphStyle]
+            textAttributes = [NSParagraphStyleAttributeName: paragraphStyle]
         }
     }
 
@@ -125,7 +135,7 @@ open class AnimatedTextInput: UIControl {
                 textInput.textAttributes = nil
                 return
             }
-            textInputAttributes.merge(dict: textAttributes!)
+            textInput.textAttributes = textInputAttributes.merge(dict: textAttributes!)
         }
     }
 
@@ -532,8 +542,9 @@ public protocol TextInputError {
 }
 
 fileprivate extension Dictionary {
-    mutating func merge(dict: [Key: Value]) {
+    mutating func merge(dict: [Key: Value]) -> Dictionary {
         for (key, value) in dict { self[key] = value }
+        return self
     }
 }
 

--- a/AnimatedTextInput/Classes/AnimatedTextInputStyle.swift
+++ b/AnimatedTextInput/Classes/AnimatedTextInputStyle.swift
@@ -15,6 +15,7 @@ public protocol AnimatedTextInputStyle {
     var bottomMargin: CGFloat { get }
     var yHintPositionOffset: CGFloat { get }
     var yPlaceholderPositionOffset: CGFloat { get }
+    var textAttributes: [String: Any]? { get }
 }
 
 public struct AnimatedTextInputStyleBlue: AnimatedTextInputStyle {
@@ -33,6 +34,8 @@ public struct AnimatedTextInputStyleBlue: AnimatedTextInputStyle {
     public let bottomMargin: CGFloat = 10
     public let yHintPositionOffset: CGFloat = 7
     public let yPlaceholderPositionOffset: CGFloat = 0
+    //Text attributes will override properties like textInputFont, textInputFontColor...
+    public let textAttributes: [String: Any]? = nil
 
     public init() { }
 }

--- a/AnimatedTextInput/Classes/AnimatedTextView.swift
+++ b/AnimatedTextInput/Classes/AnimatedTextView.swift
@@ -2,6 +2,8 @@ import UIKit
 
 final internal class AnimatedTextView: UITextView {
 
+    var textAttributes: [String: Any]?
+
     weak var textInputDelegate: TextInputDelegate?
 
     override init(frame: CGRect, textContainer: NSTextContainer?) {
@@ -30,11 +32,6 @@ extension AnimatedTextView: TextInput {
     var currentText: String? {
         get { return text }
         set { self.text = newValue }
-    }
-
-    var textAttributes: [String: Any] {
-        get { return typingAttributes }
-        set { self.typingAttributes = textAttributes }
     }
 
     var currentSelectedTextRange: UITextRange? {
@@ -66,6 +63,10 @@ extension AnimatedTextView: UITextViewDelegate {
     }
 
     func textViewDidChange(_ textView: UITextView) {
+        let range = textView.selectedRange
+        textView.attributedText = NSAttributedString(string: textView.text, attributes: textAttributes)
+        textView.selectedRange = range
+
         textInputDelegate?.textInputDidChange(textInput: self)
     }
 

--- a/AnimatedTextInput/Classes/AnimatedTextView.swift
+++ b/AnimatedTextInput/Classes/AnimatedTextView.swift
@@ -2,7 +2,12 @@ import UIKit
 
 final internal class AnimatedTextView: UITextView {
 
-    var textAttributes: [String: Any]?
+    var textAttributes: [String: Any]? {
+        didSet {
+            guard let attributes = textAttributes else { return }
+            typingAttributes = attributes
+        }
+    }
 
     weak var textInputDelegate: TextInputDelegate?
 

--- a/Example/AnimatedTextInput/ViewController.swift
+++ b/Example/AnimatedTextInput/ViewController.swift
@@ -30,6 +30,7 @@ class ViewController: UIViewController {
 
         // Text attributes (as well as any other property, can be configured using styles (AnimatedTextInputStyle) or using textInput's propoerties
         textInputs[4].lineSpacing = 15
+        textInputs[4].font = UIFont.systemFont(ofSize: 13)
     }
 
     func tap() {

--- a/Example/AnimatedTextInput/ViewController.swift
+++ b/Example/AnimatedTextInput/ViewController.swift
@@ -26,6 +26,13 @@ class ViewController: UIViewController {
         textInputs[4].placeHolderText = "Multiline"
         textInputs[4].type = .multiline
         textInputs[4].showCharacterCounterLabel(with: 160)
+
+
+        // Text attributes (as well as any other property, can be configured using styles (AnimatedTextInputStyle) or using textInput's propoerties
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.lineSpacing = 15
+        textInputs[4].textAttributes = [NSParagraphStyleAttributeName : paragraphStyle,
+                                        NSFontAttributeName : UIFont.boldSystemFont(ofSize: 18)]
     }
 
     func tap() {
@@ -73,4 +80,5 @@ struct CustomTextInputStyle: AnimatedTextInputStyle {
     let bottomMargin: CGFloat = 10
     let yHintPositionOffset: CGFloat = 7
     let yPlaceholderPositionOffset: CGFloat = 0
+    public let textAttributes: [String: Any]? = nil
 }

--- a/Example/AnimatedTextInput/ViewController.swift
+++ b/Example/AnimatedTextInput/ViewController.swift
@@ -29,10 +29,7 @@ class ViewController: UIViewController {
 
 
         // Text attributes (as well as any other property, can be configured using styles (AnimatedTextInputStyle) or using textInput's propoerties
-        let paragraphStyle = NSMutableParagraphStyle()
-        paragraphStyle.lineSpacing = 15
-        textInputs[4].textAttributes = [NSParagraphStyleAttributeName : paragraphStyle,
-                                        NSFontAttributeName : UIFont.boldSystemFont(ofSize: 18)]
+        textInputs[4].lineSpacing = 15
     }
 
     func tap() {


### PR DESCRIPTION
This PR allows the ability to work with attributed strings (including line height, requested feature).

Just by defining the text attributes (as dictionary, as you would do with a normal attributed string) and assigning them to the new `textAttributes` text input property. It can also be defined using `AnimatedTextInputStyle`.

![simulator screen shot 2 mar 2017 12 03 11](https://cloud.githubusercontent.com/assets/994334/23528433/80a1231e-ff5f-11e6-8a35-bbb8eac145ac.png)