### PR TITLE
Add support to inputAccessoryView

### DIFF
--- a/AnimatedTextInput/Classes/AnimatedTextInput.swift
+++ b/AnimatedTextInput/Classes/AnimatedTextInput.swift
@@ -139,6 +139,18 @@ open class AnimatedTextInput: UIControl {
         }
     }
 
+    private var _inputAccessoryView: UIView?
+
+    open override var inputAccessoryView: UIView? {
+        set {
+            _inputAccessoryView = newValue
+        }
+
+        get {
+            return _inputAccessoryView
+        }
+    }
+
     fileprivate let lineView = AnimatedLine()
     fileprivate let placeholderLayer = CATextLayer()
     fileprivate let counterLabel = UILabel()

--- a/Example/AnimatedTextInput/ViewController.swift
+++ b/Example/AnimatedTextInput/ViewController.swift
@@ -7,8 +7,14 @@ class ViewController: UIViewController {
     fileprivate var isBlue = true
 
     override func viewDidLoad() {
+        let inputAccessoryButton = UIButton(type: .system)
+        inputAccessoryButton.setTitle("Input accessory view", for: .normal)
+        inputAccessoryButton.frame.size.height = 64
+        inputAccessoryButton.backgroundColor = .red
+
         textInputs[0].accessibilityLabel = "standard_text_input"
         textInputs[0].placeHolderText = "Normal text"
+        textInputs[0].inputAccessoryView = inputAccessoryButton
 
         textInputs[1].placeHolderText = "Password"
         textInputs[1].type = .password


### PR DESCRIPTION
This code adds support for `inputAccessoryView`. This way, each time the `AnimatedTextInput` becomes first responder, the input view (keyboard or custom inputView) will be attached with this `inputAccessoryView`.

The code is pretty simple but in order to understand why I did it this way I would like to add some explanations.
To support `inputAccessoryView` it's needed to override UIResponder `inputAccessoryView` read-only property as Apple states in its documentation: https://developer.apple.com/reference/uikit/uiresponder/1621119-inputaccessoryview
I decided to use a private property to store the view passed through the public `inputAccessoryView` property. I thought to make `TextInput` to have `inputAccessoryView` as a required read-write property and do:
```
open override var inputAccessoryView: UIView? {
        set {
            textInput.inputAccessoryView = newValue
        }

        get {
            return textInput.inputAccessoryView
        }
    }
```
but that code produces an infinite loop trying to read `inputAccessoryView`.
For that reason, I've created a private property to store the view.

In addition, I've added to the example an `inputAccessoryView` to the first input.