### PR TITLE
Added property for autocorrection

### DIFF
--- a/AnimatedTextInput/Classes/AnimatedTextField.swift
+++ b/AnimatedTextInput/Classes/AnimatedTextField.swift
@@ -132,6 +132,11 @@ extension AnimatedTextField: TextInput {
         get { return text }
         set { self.text = newValue }
     }
+    
+    public var autocorrection: UITextAutocorrectionType {
+        get { return self.autocorrectionType }
+        set { self.autocorrectionType = newValue }
+    }
 
     public var currentSelectedTextRange: UITextRange? {
         get { return self.selectedTextRange }

--- a/AnimatedTextInput/Classes/AnimatedTextInput.swift
+++ b/AnimatedTextInput/Classes/AnimatedTextInput.swift
@@ -23,7 +23,13 @@ open class AnimatedTextInput: UIControl {
             configureType()
         }
     }
-
+    
+    open var autocorrection: UITextAutocorrectionType = .no {
+        didSet {
+            configureType()
+        }
+    }
+    
     open var returnKeyType: UIReturnKeyType = .default {
         didSet {
             textInput.changeReturnKeyType(with: returnKeyType)
@@ -291,6 +297,7 @@ open class AnimatedTextInput: UIControl {
         textInput.view.tintColor = style.activeColor
         textInput.textColor = style.textInputFontColor
         textInput.font = style.textInputFont
+        textInput.autocorrection = autocorrection
         textInput.view.translatesAutoresizingMaskIntoConstraints = false
         addSubview(textInput.view)
         invalidateIntrinsicContentSize()
@@ -559,6 +566,8 @@ public protocol TextInput {
     var currentSelectedTextRange: UITextRange? { get set }
     var currentBeginningOfDocument: UITextPosition? { get }
     var contentInset: UIEdgeInsets { get set }
+    var autocorrection: UITextAutocorrectionType {get set}
+
 
     func configureInputView(newInputView: UIView)
     func changeReturnKeyType(with newReturnKeyType: UIReturnKeyType)

--- a/AnimatedTextInput/Classes/AnimatedTextInput.swift
+++ b/AnimatedTextInput/Classes/AnimatedTextInput.swift
@@ -26,7 +26,7 @@ open class AnimatedTextInput: UIControl {
     
     open var autocorrection: UITextAutocorrectionType = .no {
         didSet {
-            configureType()
+            textInput.autocorrection = autocorrection
         }
     }
     

--- a/AnimatedTextInput/Classes/AnimatedTextView.swift
+++ b/AnimatedTextInput/Classes/AnimatedTextView.swift
@@ -60,6 +60,11 @@ extension AnimatedTextView: TextInput {
         return self.beginningOfDocument
     }
 
+    public var autocorrection: UITextAutocorrectionType {
+        get { return self.autocorrectionType }
+        set { self.autocorrectionType = newValue }
+    }
+    
     public func changeReturnKeyType(with newReturnKeyType: UIReturnKeyType) {
         returnKeyType = newReturnKeyType
     }


### PR DESCRIPTION
By adressing issue #67, I added a property to set the UITextAutocorrectionType on the underlaying UITextField / UITextView.

Is is still turned off by default but the user now has the choice to turn it on.