### PR TITLE
Expose placeholder text in UI-Tests / Voice Over

### DIFF
--- a/AnimatedTextInput/Classes/AnimatedTextInput.swift
+++ b/AnimatedTextInput/Classes/AnimatedTextInput.swift
@@ -39,6 +39,7 @@ open class AnimatedTextInput: UIControl {
     open var placeHolderText = "Test" {
         didSet {
             placeholderLayer.string = placeHolderText
+            textInput.view.accessibilityLabel = placeHolderText
         }
     }
 
@@ -341,6 +342,7 @@ open class AnimatedTextInput: UIControl {
         placeholderLayer.fontSize = fontSize
         placeholderLayer.foregroundColor = foregroundColor
         placeholderLayer.string = text
+        textInput.view.accessibilityLabel = text
         layoutPlaceholderLayer()
     }
 


### PR DESCRIPTION
## Our Need
For our UI-Tests it is necessary to have an accessible placeholder since we want to verify that the warning and error messages are shown.

Right now we saw no possible way to access this information

## What did we do?

We set the `accessibilityLabel`s of `textInput` to expose the placeholder text in UI-Tests (and Voice Over) every time the placeholder text is changed.

What do you think: Can this be merged into the library?

## Example
**Before**: Text field ("some text typed"). The placeholder is not accessible

![notaccessible_placeholder_withtext](https://user-images.githubusercontent.com/3233717/37407248-803f43ac-2799-11e8-8e63-01afc58993b9.png)


**After**: Same text field, but the placeholder is accessible through the label

![normal_placeholder_withtext](https://user-images.githubusercontent.com/3233717/37407267-8631a08e-2799-11e8-858f-f0471b81f9c7.png)
