### PR TITLE
send editingChanged action when editing

### DIFF
--- a/AnimatedTextInput/Classes/AnimatedTextInput.swift
+++ b/AnimatedTextInput/Classes/AnimatedTextInput.swift
@@ -531,6 +531,7 @@ extension AnimatedTextInput: TextInputDelegate {
 
     open func textInputDidChange(textInput: TextInput) {
         updateCounter()
+        sendActions(for: .editingChanged)
         delegate?.animatedTextInputDidChange?(animatedTextInput: self)
     }
 


### PR DESCRIPTION
In order to be able to bind the `text` value of the `AnimatedTextInput` (eg when using RxSwift), the `.editingChanged` control event needs to be sent when the text is changed.