### PR TITLE
Added maximum height for multiline label.

### DIFF
--- a/AnimatedTextInput/Classes/AnimatedTextInputFieldConfigurator.swift
+++ b/AnimatedTextInput/Classes/AnimatedTextInputFieldConfigurator.swift
@@ -10,7 +10,8 @@ public struct AnimatedTextInputFieldConfigurator {
         case phone
         case selection
         case customSelection(isRightViewEnabled: Bool, rightViewImage: UIImage?)
-        case multiline(maxHeight: CGFloat?)
+        case multiline()
+        case multilineRestricted(maxHeight: CGFloat)
         case generic(textInput: TextInput)
     }
     
@@ -28,7 +29,9 @@ public struct AnimatedTextInputFieldConfigurator {
             return AnimatedTextInputPhoneConfigurator.generate()
         case .selection:
             return AnimatedTextInputSelectionConfigurator.generate()
-        case .multiline(let maxHeight):
+        case .multiline():
+            return AnimatedTextInputMultilineConfigurator.generate(using: nil)
+        case .multilineRestricted(let maxHeight):
             return AnimatedTextInputMultilineConfigurator.generate(using: maxHeight)
         case .generic(let textInput):
             return textInput

--- a/AnimatedTextInput/Classes/AnimatedTextInputFieldConfigurator.swift
+++ b/AnimatedTextInput/Classes/AnimatedTextInputFieldConfigurator.swift
@@ -10,7 +10,7 @@ public struct AnimatedTextInputFieldConfigurator {
         case phone
         case selection
         case customSelection(isRightViewEnabled: Bool, rightViewImage: UIImage?)
-        case multiline
+        case multiline(maxHeight: CGFloat?)
         case generic(textInput: TextInput)
     }
     
@@ -28,8 +28,8 @@ public struct AnimatedTextInputFieldConfigurator {
             return AnimatedTextInputPhoneConfigurator.generate()
         case .selection:
             return AnimatedTextInputSelectionConfigurator.generate()
-        case .multiline:
-            return AnimatedTextInputMultilineConfigurator.generate()
+        case .multiline(let maxHeight):
+            return AnimatedTextInputMultilineConfigurator.generate(using: maxHeight)
         case .generic(let textInput):
             return textInput
         case .customSelection(let isRightViewEnabled, let rightViewImage):
@@ -138,12 +138,24 @@ fileprivate struct AnimatedTextInputCustomSelectionConfigurator {
 
 fileprivate struct AnimatedTextInputMultilineConfigurator {
     
-    static func generate() -> TextInput {
+    static func generate(using maxHeight: CGFloat?) -> TextInput {
         let textView = AnimatedTextView()
         textView.textContainerInset = .zero
         textView.backgroundColor = .clear
         textView.isScrollEnabled = false
         textView.autocorrectionType = .no
+
+        // Use the maximum allowed height if one is provided by the caller.
+        if let providedMaxHeight = maxHeight {
+            
+            // Pass the value along to the TextView.
+            textView.maximumHeightOfMultilineLabel = providedMaxHeight
+            
+            // Add a constraint to set the maximum height that must not be exeeded.
+            let constraint = NSLayoutConstraint(item: textView, attribute: .height, relatedBy: .lessThanOrEqual, toItem: nil, attribute: .height, multiplier: 1, constant: providedMaxHeight)
+            constraint.identifier = "MaxHeightOfTextView"
+            textView.view.addConstraint(constraint)
+        }
         return textView
     }
 }

--- a/Example/AnimatedTextInput/ViewController.swift
+++ b/Example/AnimatedTextInput/ViewController.swift
@@ -31,7 +31,7 @@ class ViewController: UIViewController {
         } as (() -> Void)
 
         textInputs[4].placeHolderText = "Multiline"
-        textInputs[4].type = .multiline(maxHeight: 100)
+        textInputs[4].type = .multilineRestricted(maxHeight: 100)
         textInputs[4].showCharacterCounterLabel(with: 160)
         textInputs[4].keyboardAppearance = .dark
         

--- a/Example/AnimatedTextInput/ViewController.swift
+++ b/Example/AnimatedTextInput/ViewController.swift
@@ -31,7 +31,7 @@ class ViewController: UIViewController {
         } as (() -> Void)
 
         textInputs[4].placeHolderText = "Multiline"
-        textInputs[4].type = .multiline
+        textInputs[4].type = .multiline(maxHeight: 100)
         textInputs[4].showCharacterCounterLabel(with: 160)
         textInputs[4].keyboardAppearance = .dark
         

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -15,7 +15,7 @@ DEPENDENCIES:
   - KIF (~> 3.5)
 
 SPEC REPOS:
-  https://github.com/cocoapods/specs:
+  https://github.com/cocoapods/specs.git:
     - FBSnapshotTestCase
     - KIF
 

--- a/Tests/SnapshotTests.swift
+++ b/Tests/SnapshotTests.swift
@@ -43,14 +43,14 @@ class AnimatedTextInputSnapshotTests: FBSnapshotTestCase {
     //Multiline type
 
     func testNormalStateMultiline() {
-        sut.type = .multiline(maxHeight: nil)
+        sut.type = .multiline()
         sut.placeHolderText = "Placeholder"
 
         verifySUT()
     }
 
     func testEmptyActiveStateMultiline() {
-        sut.type = .multiline(maxHeight: nil)
+        sut.type = .multiline()
         sut.placeHolderText = "Placeholder"
         sut.becomeFirstResponder()
 
@@ -58,7 +58,7 @@ class AnimatedTextInputSnapshotTests: FBSnapshotTestCase {
     }
 
     func testFilledActiveStateMultiline() {
-        sut.type = .multiline(maxHeight: nil)
+        sut.type = .multiline()
         sut.placeHolderText = "Placeholder"
         sut.text = "A very long text to fill a few lines. A very long text to fill a few lines. A very long text to fill a few lines. A very long text to fill a few lines"
         sut.becomeFirstResponder()
@@ -67,7 +67,7 @@ class AnimatedTextInputSnapshotTests: FBSnapshotTestCase {
     }
 
     func testFilledActiveStateMultilineWithCounter() {
-        sut.type = .multiline(maxHeight: nil)
+        sut.type = .multiline()
         sut.placeHolderText = "Placeholder"
         sut.text = "A very long text to fill a few lines. A very long text to fill a few lines. A very long text to fill a few lines. A very long text to fill a few lines"
         sut.showCharacterCounterLabel()
@@ -77,7 +77,7 @@ class AnimatedTextInputSnapshotTests: FBSnapshotTestCase {
     }
 
     func testInactiveFilledStateMultiline() {
-        sut.type = .multiline(maxHeight: nil)
+        sut.type = .multiline()
         sut.placeHolderText = "Placeholder"
         sut.text = "Input text"
 
@@ -112,7 +112,7 @@ class AnimatedTextInputSnapshotTests: FBSnapshotTestCase {
     }
 
     func testAnimatedTextFieldActiveCustomStyle() {
-        sut.type = .multiline(maxHeight: nil)
+        sut.type = .multiline()
         sut.style = CustomTextInputStyle()
         sut.placeHolderText = "Placeholder"
         sut.text = "Input text"

--- a/Tests/SnapshotTests.swift
+++ b/Tests/SnapshotTests.swift
@@ -43,14 +43,14 @@ class AnimatedTextInputSnapshotTests: FBSnapshotTestCase {
     //Multiline type
 
     func testNormalStateMultiline() {
-        sut.type = .multiline
+        sut.type = .multiline(maxHeight: nil)
         sut.placeHolderText = "Placeholder"
 
         verifySUT()
     }
 
     func testEmptyActiveStateMultiline() {
-        sut.type = .multiline
+        sut.type = .multiline(maxHeight: nil)
         sut.placeHolderText = "Placeholder"
         sut.becomeFirstResponder()
 
@@ -58,7 +58,7 @@ class AnimatedTextInputSnapshotTests: FBSnapshotTestCase {
     }
 
     func testFilledActiveStateMultiline() {
-        sut.type = .multiline
+        sut.type = .multiline(maxHeight: nil)
         sut.placeHolderText = "Placeholder"
         sut.text = "A very long text to fill a few lines. A very long text to fill a few lines. A very long text to fill a few lines. A very long text to fill a few lines"
         sut.becomeFirstResponder()
@@ -67,7 +67,7 @@ class AnimatedTextInputSnapshotTests: FBSnapshotTestCase {
     }
 
     func testFilledActiveStateMultilineWithCounter() {
-        sut.type = .multiline
+        sut.type = .multiline(maxHeight: nil)
         sut.placeHolderText = "Placeholder"
         sut.text = "A very long text to fill a few lines. A very long text to fill a few lines. A very long text to fill a few lines. A very long text to fill a few lines"
         sut.showCharacterCounterLabel()
@@ -77,7 +77,7 @@ class AnimatedTextInputSnapshotTests: FBSnapshotTestCase {
     }
 
     func testInactiveFilledStateMultiline() {
-        sut.type = .multiline
+        sut.type = .multiline(maxHeight: nil)
         sut.placeHolderText = "Placeholder"
         sut.text = "Input text"
 
@@ -112,7 +112,7 @@ class AnimatedTextInputSnapshotTests: FBSnapshotTestCase {
     }
 
     func testAnimatedTextFieldActiveCustomStyle() {
-        sut.type = .multiline
+        sut.type = .multiline(maxHeight: nil)
         sut.style = CustomTextInputStyle()
         sut.placeHolderText = "Placeholder"
         sut.text = "Input text"


### PR DESCRIPTION
This PR is a response to #105. It implements a maximum height for a multiline TextView.

The new limit can be configured by setting an associated value to the ```AnimatedTextInputType```-Enum case ```.multiline``` like this: ```.multiline(maxHeight: 150)```.

If the multiline label should not be limited in height, the user specifies ```.multiline(maxHeight: nil)```.